### PR TITLE
Fix `target_compatible_with` for cross compile

### DIFF
--- a/elm/toolchain.bzl
+++ b/elm/toolchain.bzl
@@ -70,13 +70,11 @@ toolchain(
     toolchain_type = "@rules_elm//elm:toolchain",
     toolchain = "@{bindist_name}//:{os}_info",
     exec_compatible_with = {exec_constraints},
-    target_compatible_with = {target_constraints},
 )
         """.format(
             os = ctx.attr.os,
             bindist_name = ctx.attr.bindist_name,
             exec_constraints = exec_constraints,
-            target_constraints = exec_constraints,
         ),
     )
 


### PR DESCRIPTION
Occur error when use rules_elm with cross compilable rules (e.g. rules_go).

```
$ bazelisk build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //:app
ERROR: While resolving toolchains for target //:mainjs: no matching toolchains found for types @rules_elm//elm:toolchain
ERROR: Analysis of target '//:app' failed; build aborted: no matching toolchains found for types @rules_elm//elm:toolchain
INFO: Elapsed time: 0.360s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (45 packages loaded, 101 targets configured)
FAILED: Build did NOT complete successfully (45 packages loaded, 101 targets configured)
    Fetching @local_config_xcode; fetching
    Fetching @bazel_gazelle_go_repository_config; Restarting.
```

Reason is that `target_compatible_with` is same `exec_compatible_with` .
So, fix it (change `target_compatible_with` to any).