### PR TITLE
Fix gunzip for elm binary

### DIFF
--- a/elm/toolchain.bzl
+++ b/elm/toolchain.bzl
@@ -41,6 +41,13 @@ def _elm_compiler_impl(ctx):
         sha256 = ctx.attr.checksum,
         output = file_name + ".gz",
     )
+
+    if ctx.which("gzip") == None:
+        fail("require gzip, but is not exist.")
+
+    if ctx.which("chmod") == None:
+        fail("require chmod, but is not exist.")
+
     ctx.execute([ctx.which("gzip"), "-d", file_name + ".gz"])
     ctx.execute([ctx.which("chmod"), "+x", file_name])
 

--- a/elm/toolchain.bzl
+++ b/elm/toolchain.bzl
@@ -42,15 +42,6 @@ def _elm_compiler_impl(ctx):
         output = file_name + ".gz",
     )
 
-    if ctx.which("gzip") == None:
-        fail("require gzip, but is not exist.")
-
-    if ctx.which("chmod") == None:
-        fail("require chmod, but is not exist.")
-
-    ctx.execute([ctx.which("gzip"), "-d", file_name + ".gz"])
-    ctx.execute([ctx.which("chmod"), "+x", file_name])
-
     test_version = ctx.attr.test_version
     if not ELM_TEST_BINDIST.get(test_version):
         fail("Binary distribution of elm-test-rs {} is not available.".format(test_version))
@@ -74,8 +65,9 @@ def _elm_compiler_impl(ctx):
         "BUILD",
         executable = False,
         content = """
-load("@rules_elm//elm:toolchain.bzl", "elm_toolchain")
-exports_files(["{elm}", "{elm_test}"])
+load("@rules_elm//elm:toolchain.bzl", "elm_toolchain", "extract_gzip")
+exports_files(["{elm}.gz", "{elm_test}"])
+extract_gzip(name = "{elm}", archive = "{elm}.gz")
 elm_toolchain(name = "{os}_info", elm = ":{elm}", elm_test = ":{elm_test}")
         """.format(os = os, elm = file_name, elm_test = elm_test_name),
     )
@@ -156,4 +148,33 @@ elm_toolchain = rule(
             mandatory = True,
         ),
     },
+)
+
+def _extract_gzip_imp(ctx):
+    archive = ctx.file.archive
+    elm_compiler = ctx.actions.declare_file(ctx.label.name, sibling = archive)
+
+    ctx.actions.run_shell(
+        inputs = [ctx.file.archive],
+        outputs = [elm_compiler],
+        command ="""
+        gunzip "{archive}" -c > "{output}"
+        chmod +x "{output}"
+        """.format(
+            archive = ctx.file.archive.path,
+            output = elm_compiler.path,
+        ),
+    )
+
+    return [DefaultInfo(executable = elm_compiler)]
+
+extract_gzip = rule(
+    implementation = _extract_gzip_imp,
+    attrs = {
+        "archive": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+        ),
+    },
+    provides = [DefaultInfo],
 )


### PR DESCRIPTION
Maybe, when use [repository_cache](https://bazel.build/designs/2016/09/30/repository-cache.html), occur error:

```
(14:13:36) ERROR: /path/to/BUILD.bazel:14:17: Action /.../.elm.zip failed: missing input file 'external/rules_elm_compiler_linux/elm', owner: '@rules_elm_compiler_linux//:elm'
```

I think, repository_cache is cached without `ctx.exec`.
Elm toolchain is used `ctx.exec` to gunzip elm compiler binary in rule_elm.
So, I maked `extract_gzip` rule as another way to gunzip.
